### PR TITLE
Update s3_enable_logging.py to use bucket policy instead of ACL

### DIFF
--- a/bots/s3_enable_logging.py
+++ b/bots/s3_enable_logging.py
@@ -20,7 +20,10 @@ def run_action(boto_session,rule,entity,params):
     bucket_logging = s3_resource.BucketLogging(bucket_name)
 
     target_bucket_name = accountNumber + "s3accesslogs" + region
-
+    bucket_policy = '{"Version": "2012-10-17", \
+    "Statement": [ {"Sid": "S3ServerAccessLogsPolicy", \
+    "Effect": "Allow", "Principal": {"Service": "logging.s3.amazonaws.com"},\
+    "Action": "s3:PutObject", "Resource": "arn:aws:s3:::'+target_bucket_name+'/*"}]}'
     #The target bucket needs to be in the same region as the remediation bucket or it'll throw a CrossLocationLoggingProhibitted error.
     try:
         #Check if the bucket exists. If not, create one

--- a/bots/s3_enable_logging.py
+++ b/bots/s3_enable_logging.py
@@ -31,21 +31,18 @@ def run_action(boto_session,rule,entity,params):
         try:
             if region == "us-east-1":
                 result = s3_client.create_bucket(
-                    Bucket=target_bucket_name,
-                    ACL='log-delivery-write'
+                    Bucket=target_bucket_name
                     )
             elif region == "eu-west-1":
                 region = "EU"
                 result = s3_client.create_bucket(
                     Bucket=target_bucket_name,
-                    CreateBucketConfiguration={'LocationConstraint': region},
-                    ACL='log-delivery-write'
+                    CreateBucketConfiguration={'LocationConstraint': region}
                     )
             else:
                 result = s3_client.create_bucket(
                     Bucket=target_bucket_name,
-                    CreateBucketConfiguration={'LocationConstraint': region},
-                    ACL='log-delivery-write'
+                    CreateBucketConfiguration={'LocationConstraint': region}
                     )
             
             responseCode = result['ResponseMetadata']['HTTPStatusCode']
@@ -53,7 +50,17 @@ def run_action(boto_session,rule,entity,params):
                 text_output = "Unexpected error: %s \n" % str(result)
             else:
                 text_output = "Logging bucket created %s \n" % target_bucket_name
-       
+            try:
+                    result = s3_client.put_bucket_policy(Bucket=target_bucket_name,Policy=bucket_policy)
+            except ClientError as e:
+                text_output = text_output + "Unexpected error: %s \n" % e
+
+            responseCode = result['ResponseMetadata']['HTTPStatusCode']
+            if responseCode >= 400:
+                text_output = text_output + "Unexpected error: %s \n" % str(result)
+            else:
+                text_output = text_output + "bucket policy created %s \n" % target_bucket_name
+
         except ClientError as e:
             text_output = "Unexpected error: %s \n" % e
 


### PR DESCRIPTION
as AWS has [disabled ACL by default](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) This bot has stopped working, unless the target bucket already exists. 
I have converted the bot too use a bucket policy instead of ACL's to align with AWS best practices. 
this also addresses #161 